### PR TITLE
Adding missing include

### DIFF
--- a/code/utils/include/insieme/utils/constraint.h
+++ b/code/utils/include/insieme/utils/constraint.h
@@ -49,6 +49,7 @@
 #endif
 
 #include <boost/operators.hpp>
+#include <boost/mpl/and.hpp>
 #include <boost/mpl/or.hpp>
 #include <boost/type_traits.hpp>
 #include <boost/utility/enable_if.hpp>


### PR DESCRIPTION
This is include is necessary for newer boost versions.